### PR TITLE
CDI-2213: Caps Lock and Shift buttons, stuck Caps Lock in the VNC console

### DIFF
--- a/app/images/capslock.svg
+++ b/app/images/capslock.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns="http://www.w3.org/2000/svg"
+   width="25"
+   height="25"
+   viewBox="0 0 25 25"
+   version="1.1"
+   id="svg-capslock">
+  <path
+     d="M 12.5,2.5 21,11 H 16.5 V 17.5 H 8.5 V 11 H 4 Z"
+     style="fill:#ffffff;fill-opacity:1;stroke:none"
+     id="path-capslock-arrow" />
+  <rect
+     x="8.5"
+     y="19.5"
+     width="8"
+     height="3"
+     style="fill:#ffffff;fill-opacity:1;stroke:none"
+     id="path-capslock-bar" />
+</svg>

--- a/app/images/shift.svg
+++ b/app/images/shift.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns="http://www.w3.org/2000/svg"
+   width="25"
+   height="25"
+   viewBox="0 0 25 25"
+   version="1.1"
+   id="svg-shift">
+  <path
+     d="M 12.5,3.5 21,12 H 16.5 V 20.5 H 8.5 V 12 H 4 Z"
+     style="fill:#ffffff;fill-opacity:1;stroke:none"
+     id="path-shift" />
+</svg>

--- a/app/ui.js
+++ b/app/ui.js
@@ -277,6 +277,10 @@ const UI = {
             .addEventListener('click', UI.toggleWindows);
         document.getElementById("noVNC_toggle_alt_button")
             .addEventListener('click', UI.toggleAlt);
+        document.getElementById("noVNC_toggle_shift_button")
+            .addEventListener('click', UI.toggleShift);
+        document.getElementById("noVNC_send_capslock_button")
+            .addEventListener('click', UI.sendCapsLock);
         document.getElementById("noVNC_send_tab_button")
             .addEventListener('click', UI.sendTab);
         document.getElementById("noVNC_send_esc_button")
@@ -1099,6 +1103,7 @@ const UI = {
         UI.rfb.addEventListener("clipboard", UI.clipboardReceive);
         UI.rfb.addEventListener("bell", UI.bell);
         UI.rfb.addEventListener("desktopname", UI.updateDesktopName);
+        UI.rfb.addEventListener("ledstate", UI.updateCapsLock);
         UI.rfb.clipViewport = UI.getSetting('view_clip');
         UI.rfb.scaleViewport = true;
         // UI.rfb.scaleViewport = UI.getSetting('resize') === 'scale';
@@ -1171,6 +1176,9 @@ const UI = {
         UI.connected = false;
 
         UI.rfb = undefined;
+        // Guest lock state is unknown without a connection
+        document.getElementById('noVNC_send_capslock_button')
+            .classList.remove("noVNC_selected");
 
         if (!e.detail.clean) {
             UI.updateVisualState('disconnected');
@@ -1600,6 +1608,28 @@ const UI = {
             UI.rfb.sendKey(KeyTable.XK_Alt_L, "AltLeft", true);
             btn.classList.add("noVNC_selected");
         }
+    },
+
+    toggleShift() {
+        const btn = document.getElementById('noVNC_toggle_shift_button');
+        if (btn.classList.contains("noVNC_selected")) {
+            UI.rfb.sendKey(KeyTable.XK_Shift_L, "ShiftLeft", false);
+            btn.classList.remove("noVNC_selected");
+        } else {
+            UI.rfb.sendKey(KeyTable.XK_Shift_L, "ShiftLeft", true);
+            btn.classList.add("noVNC_selected");
+        }
+    },
+
+    sendCapsLock() {
+        UI.rfb.sendKey(KeyTable.XK_Caps_Lock, "CapsLock");
+    },
+
+    // The highlight mirrors the Caps Lock LED reported by the server,
+    // not a key held by the button like the modifier toggles above.
+    updateCapsLock(e) {
+        document.getElementById('noVNC_send_capslock_button')
+            .classList.toggle("noVNC_selected", e.detail.capsLock);
     },
 
     sendCtrlAltDel() {

--- a/app/ui.js
+++ b/app/ui.js
@@ -977,13 +977,13 @@ const UI = {
 
     writeText() {
         const text = document.getElementById('noVNC_clipboard_text').value;
-        Log.Debug(">> UI.clipboardSend: " + text.substr(0, 40) + "...");
+        Log.Debug(">> UI.clipboardSend: " + text.length + " characters");
         const textClip = text.trim().split("");
         function f(t) {
             const character = t.shift();
             if (character === undefined) return;
             let code = character.charCodeAt();
-            const needs_shift = '^[AZ]!@#$%^&*()_+{}:"<>?~|'.indexOf(character) !== -1;
+            const needs_shift = /^[A-Z]$/.test(character) || '~!@#$%^&*()_+{}|:"<>?'.indexOf(character) !== -1;
             const enter = '[\n]'.indexOf(character) !== -1;
             const tab = '[\t]'.indexOf(character) !== -1;
             if (code === 91) {

--- a/core/encodings.js
+++ b/core/encodings.js
@@ -20,6 +20,7 @@ export const encodings = {
     pseudoEncodingLastRect: -224,
     pseudoEncodingCursor: -239,
     pseudoEncodingQEMUExtendedKeyEvent: -258,
+    pseudoEncodingQEMULedEvent: -261,
     pseudoEncodingExtendedDesktopSize: -308,
     pseudoEncodingXvp: -309,
     pseudoEncodingFence: -312,

--- a/core/input/keyboard.js
+++ b/core/input/keyboard.js
@@ -39,7 +39,7 @@ export default class Keyboard {
 
     // ===== PRIVATE METHODS =====
 
-    _sendKeyEvent(keysym, code, down) {
+    _sendKeyEvent(keysym, code, down, numlock = null) {
         if (down) {
             this._keyDownList[code] = keysym;
         } else {
@@ -52,7 +52,7 @@ export default class Keyboard {
 
         Log.Debug("onkeyevent " + (down ? "down" : "up") +
                   ", keysym: " + keysym, ", code: " + code);
-        this.onkeyevent(keysym, code, down);
+        this.onkeyevent(keysym, code, down, numlock);
     }
 
     _getKeyCode(e) {
@@ -91,6 +91,13 @@ export default class Keyboard {
     _handleKeyDown(e) {
         const code = this._getKeyCode(e);
         let keysym = KeyboardUtil.getKeysym(e);
+        let numlock = e.getModifierState('NumLock');
+
+        // getModifierState for NumLock is not supported on mac and ios and always returns false.
+        // Set to null to indicate unknown/unsupported instead.
+        if (browser.isMac() || browser.isIOS()) {
+            numlock = null;
+        }
 
         // Windows doesn't have a proper AltGr, but handles it using
         // fake Ctrl+Alt. However the remote end might not be Windows,
@@ -112,7 +119,7 @@ export default class Keyboard {
                 //        key to "AltGraph".
                 keysym = KeyTable.XK_ISO_Level3_Shift;
             } else {
-                this._sendKeyEvent(KeyTable.XK_Control_L, "ControlLeft", true);
+                this._sendKeyEvent(KeyTable.XK_Control_L, "ControlLeft", true, numlock);
             }
         }
 
@@ -125,8 +132,8 @@ export default class Keyboard {
                 // If it's a virtual keyboard then it should be
                 // sufficient to just send press and release right
                 // after each other
-                this._sendKeyEvent(keysym, code, true);
-                this._sendKeyEvent(keysym, code, false);
+                this._sendKeyEvent(keysym, code, true, numlock);
+                this._sendKeyEvent(keysym, code, false, numlock);
             }
 
             stopEvent(e);
@@ -165,8 +172,8 @@ export default class Keyboard {
         // which toggles on each press, but not on release. So pretend
         // it was a quick press and release of the button.
         if (browser.isMac() && (code === 'CapsLock')) {
-            this._sendKeyEvent(KeyTable.XK_Caps_Lock, 'CapsLock', true);
-            this._sendKeyEvent(KeyTable.XK_Caps_Lock, 'CapsLock', false);
+            this._sendKeyEvent(KeyTable.XK_Caps_Lock, 'CapsLock', true, numlock);
+            this._sendKeyEvent(KeyTable.XK_Caps_Lock, 'CapsLock', false, numlock);
             stopEvent(e);
             return;
         }
@@ -196,7 +203,7 @@ export default class Keyboard {
             return;
         }
 
-        this._sendKeyEvent(keysym, code, true);
+        this._sendKeyEvent(keysym, code, true, numlock);
     }
 
     // Legacy event for browsers without code/key

--- a/core/rfb.js
+++ b/core/rfb.js
@@ -176,6 +176,7 @@ export default class RFB extends EventTargetMixin {
 
         this._keyboard = new Keyboard(this._canvas);
         this._keyboard.onkeyevent = this._handleKeyEvent.bind(this);
+        this._remoteNumLock = null; // Null indicates unknown or irrelevant
 
         this._mouse = new Mouse(this._canvas);
         this._mouse.onmousebutton = this._handleMouseButton.bind(this);
@@ -715,7 +716,23 @@ export default class RFB extends EventTargetMixin {
         }
     }
 
-    _handleKeyEvent(keysym, code, down) {
+    _handleKeyEvent(keysym, code, down, numlock) {
+        // If remote state of numlock is known, and it doesn't match the local led state of
+        // the keyboard, we send a numlock keypress first to bring it into sync.
+        // If we just pressed NumLock, or we toggled it remotely due to it being out of sync
+        // we clear the remote state so that we don't send duplicate or spurious fixes,
+        // since it may take some time to receive the new remote NumLock state.
+        // Caps Lock is deliberately not synced: the guest keeps its own state, which
+        // the physical key and the toolbar button toggle directly.
+        if (code == 'NumLock' && down) {
+            this._remoteNumLock = null;
+        }
+        if (this._remoteNumLock !== null && numlock !== null && this._remoteNumLock !== numlock && down) {
+            Log.Debug("Fixing remote num lock");
+            this.sendKey(KeyTable.XK_Num_Lock, 'NumLock', true);
+            this.sendKey(KeyTable.XK_Num_Lock, 'NumLock', false);
+            this._remoteNumLock = null;
+        }
         this.sendKey(keysym, code, down);
     }
 
@@ -1240,6 +1257,7 @@ export default class RFB extends EventTargetMixin {
         encs.push(encodings.pseudoEncodingDesktopSize);
         encs.push(encodings.pseudoEncodingLastRect);
         encs.push(encodings.pseudoEncodingQEMUExtendedKeyEvent);
+        encs.push(encodings.pseudoEncodingQEMULedEvent);
         encs.push(encodings.pseudoEncodingExtendedDesktopSize);
         encs.push(encodings.pseudoEncodingXvp);
         encs.push(encodings.pseudoEncodingFence);
@@ -1517,6 +1535,9 @@ export default class RFB extends EventTargetMixin {
             case encodings.pseudoEncodingExtendedDesktopSize:
                 return this._handleExtendedDesktopSize();
 
+            case encodings.pseudoEncodingQEMULedEvent:
+                return this._handleLedEvent();
+
             default:
                 return this._handleDataRect();
         }
@@ -1555,6 +1576,24 @@ export default class RFB extends EventTargetMixin {
         }
 
         this._updateCursor(rgba, hotx, hoty, w, h);
+
+        return true;
+    }
+
+    _handleLedEvent() {
+        if (this._sock.rQwait("LED Status", 1)) {
+            return false;
+        }
+
+        let data = this._sock.rQshift8();
+        // ScrollLock state can be retrieved with data & 1. This is currently not needed.
+        let numLock = data & 2 ? true : false;
+        let capsLock = data & 4 ? true : false;
+        this._remoteNumLock = numLock;
+
+        this.dispatchEvent(new CustomEvent(
+            "ledstate",
+            { detail: { capsLock: capsLock, numLock: numLock } }));
 
         return true;
     }

--- a/docs/API.md
+++ b/docs/API.md
@@ -106,6 +106,10 @@ protocol stream.
   - The `capabilities` event is fired when `RFB.capabilities` is
     updated.
 
+[`ledstate`](#ledstate)
+  - The `ledstate` event is fired when the server reports the state
+    of the remote lock keys.
+
 ### Methods
 
 [`RFB.disconnect()`](#rfbdisconnect)
@@ -250,6 +254,12 @@ which is a `DOMString` specifying the new name.
 The `capabilities` event is fired whenever an entry is added or removed
 from `RFB.capabilities`. The `detail` property is an `Object` with the
 property `capabilities` containing the new value of `RFB.capabilities`.
+
+#### ledstate
+
+The `ledstate` event is fired when the server reports the state of the
+remote lock keys (QEMU LED state extension). The `detail` property is
+an `Object` with the `boolean` properties `capsLock` and `numLock`.
 
 #### RFB.disconnect()
 

--- a/vnc.html
+++ b/vnc.html
@@ -130,6 +130,12 @@
                         <input type="image" alt="Windows" src="app/images/windows.svg"
                                id="noVNC_toggle_windows_button" class="noVNC_button"
                                title="Toggle Windows">
+                        <input type="image" alt="Shift" src="app/images/shift.svg"
+                               id="noVNC_toggle_shift_button" class="noVNC_button"
+                               title="Toggle Shift">
+                        <input type="image" alt="Caps Lock" src="app/images/capslock.svg"
+                               id="noVNC_send_capslock_button" class="noVNC_button"
+                               title="Send Caps Lock">
                         <input type="image" alt="Tab" src="app/images/tab.svg"
                                id="noVNC_send_tab_button" class="noVNC_button"
                                title="Send Tab">


### PR DESCRIPTION
## CDI-2213: Caps Lock and Shift buttons, stuck Caps Lock in the VNC console

### Problem
After pasting text through the clipboard panel the guest is often left with Caps Lock enabled: typed letters are inverted, pasted passwords are garbled and the player's physical Caps Lock does not fix it. The control bar offers no way out.

### Root causes
1. `writeText()` compared characters against the literal string `'^[AZ]...'` instead of an A-Z range, so uppercase B-Y were sent without Shift. QEMU (lock-key-sync, its default) then toggled the guest Caps Lock to match the case.
2. With lock-key-sync QEMU also undoes any Caps Lock press sent by the client at the next letter, which is why the physical key appeared dead. Advertising the LED state pseudo-encoding (-261) makes QEMU leave lock keys to the client.

### Changes
- `send Shift for all uppercase letters in clipboard paste` - fixes the paste; pasted text is no longer written to the debug log.
- `advertise QEMU LED state and sync Num Lock from the client` - backport of upstream noVNC a0b7c0d (`-261`, LED rect parsing, `ledstate` event, Num Lock sync). Caps Lock is deliberately not auto-synced: the guest keeps its own state, toggled directly by the key or the button.
- `add Caps Lock and Shift buttons to the control bar` - Shift is sticky like Ctrl/Alt/Win; Caps Lock sends a single press like Tab/Esc and its highlight mirrors the guest Caps Lock LED (cleared on disconnect).

### Verification
Local replica of production (QEMU 10.0, `lock-key-sync=on`, no `-k`, websockify, this client), driven through Chrome DevTools, guest state read from QEMU screendumps:
- original client: stuck Caps Lock cannot be cleared by the physical key or a button, paste `hasloB` arrives as `HASLOb`;
- this branch: button toggles the guest Caps Lock both ways (`aaaBBBccc`), stuck Caps Lock cleared by button (`ddd`) and by the physical key (`EEEfff`), pastes `hasloB` / `AbCxYz` / `P@ss{W}ord_1!` arrive verbatim, Shift latch `ZSHIFTEM` -> `bezshiftu`, indicator follows the LED including across reconnect, no JS errors.

### Notes
- QEMU sends LED updates only with `lock-key-sync=on` (default; production uses defaults). With `off` the buttons still work, only the indicator stays unknown.
- Caps Lock toggled in another window is not auto-followed any more (QEMU used to do that); the indicator shows the guest state and one press fixes it.
- Upstream noVNC 1.5+ auto-syncs Caps Lock from the local keyboard; a future upgrade must keep that disabled or the button will be undone at the next keystroke.
- Translation catalogues not updated: this fork hardcodes `['en']` in `app/localization.js` and the `po/` toolchain is not runnable here.
