### PR TITLE
CDI-2213: follow the local Caps Lock in the guest

### DIFF
--- a/app/ui.js
+++ b/app/ui.js
@@ -982,12 +982,26 @@ const UI = {
     writeText() {
         const text = document.getElementById('noVNC_clipboard_text').value;
         Log.Debug(">> UI.clipboardSend: " + text.length + " characters");
+        // Letters are typed as written whatever the guest Caps Lock state,
+        // which the Caps Lock button highlight mirrors
+        const capsLock = document.getElementById('noVNC_send_capslock_button')
+            .classList.contains("noVNC_selected");
         const textClip = text.trim().split("");
+        // the guest Caps Lock must not change under the text being typed
+        UI.rfb.capsLockSync = false;
         function f(t) {
+            if (!UI.rfb) return;
             const character = t.shift();
-            if (character === undefined) return;
+            if (character === undefined) {
+                UI.rfb.capsLockSync = true;
+                UI.rfb.focus();
+                return;
+            }
             let code = character.charCodeAt();
-            const needs_shift = /^[A-Z]$/.test(character) || '~!@#$%^&*()_+{}|:"<>?'.indexOf(character) !== -1;
+            const upper = /^[A-Z]$/.test(character);
+            const lower = /^[a-z]$/.test(character);
+            const needs_shift = (upper || lower) ? (upper !== capsLock)
+                : '~!@#$%^&*()_+{}|:"<>?'.indexOf(character) !== -1;
             const enter = '[\n]'.indexOf(character) !== -1;
             const tab = '[\t]'.indexOf(character) !== -1;
             if (code === 91) {
@@ -1013,13 +1027,9 @@ const UI = {
                     UI.rfb.sendKey(KeyTable.XK_Shift_L, "ShiftLeft", false);
                 }
             }
-            if (t.length > 0) {
-                setTimeout( () => {
-                    f(t);
-                }, 50);
-            } else {
-                UI.rfb.focus();
-            }
+            setTimeout(() => {
+                f(t);
+            }, 50);
         }
 
         f(textClip);
@@ -1622,7 +1632,7 @@ const UI = {
     },
 
     sendCapsLock() {
-        UI.rfb.sendKey(KeyTable.XK_Caps_Lock, "CapsLock");
+        UI.rfb.toggleCapsLock();
     },
 
     // The highlight mirrors the Caps Lock LED reported by the server,

--- a/core/input/keyboard.js
+++ b/core/input/keyboard.js
@@ -39,7 +39,7 @@ export default class Keyboard {
 
     // ===== PRIVATE METHODS =====
 
-    _sendKeyEvent(keysym, code, down, numlock = null) {
+    _sendKeyEvent(keysym, code, down, numlock = null, capslock = null) {
         if (down) {
             this._keyDownList[code] = keysym;
         } else {
@@ -52,7 +52,7 @@ export default class Keyboard {
 
         Log.Debug("onkeyevent " + (down ? "down" : "up") +
                   ", keysym: " + keysym, ", code: " + code);
-        this.onkeyevent(keysym, code, down, numlock);
+        this.onkeyevent(keysym, code, down, numlock, capslock);
     }
 
     _getKeyCode(e) {
@@ -92,11 +92,16 @@ export default class Keyboard {
         const code = this._getKeyCode(e);
         let keysym = KeyboardUtil.getKeysym(e);
         let numlock = e.getModifierState('NumLock');
+        let capslock = e.getModifierState('CapsLock');
 
         // getModifierState for NumLock is not supported on mac and ios and always returns false.
         // Set to null to indicate unknown/unsupported instead.
         if (browser.isMac() || browser.isIOS()) {
             numlock = null;
+        }
+        // iOS does not report a meaningful Caps Lock state
+        if (browser.isIOS()) {
+            capslock = null;
         }
 
         // Windows doesn't have a proper AltGr, but handles it using
@@ -119,7 +124,7 @@ export default class Keyboard {
                 //        key to "AltGraph".
                 keysym = KeyTable.XK_ISO_Level3_Shift;
             } else {
-                this._sendKeyEvent(KeyTable.XK_Control_L, "ControlLeft", true, numlock);
+                this._sendKeyEvent(KeyTable.XK_Control_L, "ControlLeft", true, numlock, capslock);
             }
         }
 
@@ -132,8 +137,8 @@ export default class Keyboard {
                 // If it's a virtual keyboard then it should be
                 // sufficient to just send press and release right
                 // after each other
-                this._sendKeyEvent(keysym, code, true, numlock);
-                this._sendKeyEvent(keysym, code, false, numlock);
+                this._sendKeyEvent(keysym, code, true, numlock, capslock);
+                this._sendKeyEvent(keysym, code, false, numlock, capslock);
             }
 
             stopEvent(e);
@@ -172,8 +177,8 @@ export default class Keyboard {
         // which toggles on each press, but not on release. So pretend
         // it was a quick press and release of the button.
         if (browser.isMac() && (code === 'CapsLock')) {
-            this._sendKeyEvent(KeyTable.XK_Caps_Lock, 'CapsLock', true, numlock);
-            this._sendKeyEvent(KeyTable.XK_Caps_Lock, 'CapsLock', false, numlock);
+            this._sendKeyEvent(KeyTable.XK_Caps_Lock, 'CapsLock', true, numlock, capslock);
+            this._sendKeyEvent(KeyTable.XK_Caps_Lock, 'CapsLock', false, numlock, capslock);
             stopEvent(e);
             return;
         }
@@ -203,7 +208,7 @@ export default class Keyboard {
             return;
         }
 
-        this._sendKeyEvent(keysym, code, true, numlock);
+        this._sendKeyEvent(keysym, code, true, numlock, capslock);
     }
 
     // Legacy event for browsers without code/key

--- a/core/input/mouse.js
+++ b/core/input/mouse.js
@@ -195,7 +195,10 @@ export default class Mouse {
 
     _handleMouseMove(e) {
         this._updateMousePosition(e);
-        this.onmousemove(this._pos.x, this._pos.y);
+        // touch events carry no modifier state
+        const capslock = typeof e.getModifierState === 'function' ?
+            e.getModifierState('CapsLock') : null;
+        this.onmousemove(this._pos.x, this._pos.y, capslock);
         stopEvent(e);
     }
 

--- a/core/rfb.js
+++ b/core/rfb.js
@@ -9,7 +9,7 @@
 
 import * as Log from './util/logging.js';
 import { decodeUTF8 } from './util/strings.js';
-import { dragThreshold } from './util/browser.js';
+import { dragThreshold, isIOS } from './util/browser.js';
 import EventTargetMixin from './util/eventtarget.js';
 import Display from "./display.js";
 import Keyboard from "./input/keyboard.js";
@@ -177,6 +177,11 @@ export default class RFB extends EventTargetMixin {
         this._keyboard = new Keyboard(this._canvas);
         this._keyboard.onkeyevent = this._handleKeyEvent.bind(this);
         this._remoteNumLock = null; // Null indicates unknown or irrelevant
+        this._remoteCapsLock = null;
+        this._capsLockInverted = false;     // Relation kept between remote and local Caps Lock
+                                            // (null: learn it from the next sync)
+        this._capsLockAwaitingLed = false;  // A Caps Lock press of ours is not yet reported back
+        this._capsLockSync = true;
 
         this._mouse = new Mouse(this._canvas);
         this._mouse.onmousebutton = this._handleMouseButton.bind(this);
@@ -250,6 +255,9 @@ export default class RFB extends EventTargetMixin {
     }
 
     // ===== PROPERTIES =====
+
+    get capsLockSync() { return this._capsLockSync; }
+    set capsLockSync(enabled) { this._capsLockSync = enabled; }
 
     get viewOnly() { return this._viewOnly; }
     set viewOnly(viewOnly) {
@@ -333,6 +341,16 @@ export default class RFB extends EventTargetMixin {
         this.sendKey(KeyTable.XK_Delete, "Delete", false);
         this.sendKey(KeyTable.XK_Alt_L, "AltLeft", false);
         this.sendKey(KeyTable.XK_Control_L, "ControlLeft", false);
+    }
+
+    toggleCapsLock() {
+        if (this._rfb_connection_state !== 'connected' || this._viewOnly) { return; }
+        this.sendKey(KeyTable.XK_Caps_Lock, "CapsLock");
+        this._capsLockAwaitingLed = true;
+        // The relation to the local Caps Lock is learned again once the
+        // guest has reported the new state, so the sync keeps the
+        // toggled state instead of undoing it
+        this._capsLockInverted = null;
     }
 
     machineShutdown() {
@@ -716,14 +734,22 @@ export default class RFB extends EventTargetMixin {
         }
     }
 
-    _handleKeyEvent(keysym, code, down, numlock) {
+    _handleKeyEvent(keysym, code, down, numlock, capslock) {
+        // The guest Caps Lock follows the local keyboard, optionally kept
+        // opposite to it by the Caps Lock toolbar button. Nothing is learned
+        // or fixed while Caps Lock presses of ours still wait for the guest
+        // to report their effect, so LED updates in flight cannot undo them.
+        if (code == 'CapsLock' && down) {
+            this._capsLockAwaitingLed = true;
+        } else if (down) {
+            this._syncCapsLock(capslock);
+        }
+
         // If remote state of numlock is known, and it doesn't match the local led state of
         // the keyboard, we send a numlock keypress first to bring it into sync.
         // If we just pressed NumLock, or we toggled it remotely due to it being out of sync
         // we clear the remote state so that we don't send duplicate or spurious fixes,
         // since it may take some time to receive the new remote NumLock state.
-        // Caps Lock is deliberately not synced: the guest keeps its own state, which
-        // the physical key and the toolbar button toggle directly.
         if (code == 'NumLock' && down) {
             this._remoteNumLock = null;
         }
@@ -734,6 +760,21 @@ export default class RFB extends EventTargetMixin {
             this._remoteNumLock = null;
         }
         this.sendKey(keysym, code, down);
+    }
+
+    _syncCapsLock(capslock) {
+        if (this._rfb_connection_state !== 'connected' || this._viewOnly ||
+            !this._capsLockSync || this._capsLockAwaitingLed ||
+            this._remoteCapsLock === null || capslock === null) { return; }
+        if (this._capsLockInverted === null) {
+            this._capsLockInverted = this._remoteCapsLock !== capslock;
+        }
+        const expected = capslock !== this._capsLockInverted;
+        if (this._remoteCapsLock !== expected) {
+            Log.Debug("Fixing remote caps lock");
+            this.sendKey(KeyTable.XK_Caps_Lock, 'CapsLock');
+            this._capsLockAwaitingLed = true;
+        }
     }
 
     _handleMouseButton(x, y, down, bmask) {
@@ -776,7 +817,13 @@ export default class RFB extends EventTargetMixin {
         RFB.messages.pointerEvent(this._sock, this._display.absX(x), this._display.absY(y), this._mouse_buttonMask);
     }
 
-    _handleMouseMove(x, y) {
+    _handleMouseMove(x, y, capslock) {
+        // Pointer events also carry the local Caps Lock state, so a change
+        // made outside the console is followed as soon as the pointer is
+        // back over it, before the first key is typed
+        if (capslock !== null && !isIOS()) {
+            this._syncCapsLock(capslock);
+        }
         if (this._viewportDragging) {
             const deltaX = this._viewportDragPos.x - x;
             const deltaY = this._viewportDragPos.y - y;
@@ -1590,6 +1637,18 @@ export default class RFB extends EventTargetMixin {
         let numLock = data & 2 ? true : false;
         let capsLock = data & 4 ? true : false;
         this._remoteNumLock = numLock;
+        // The first report only establishes the baseline; later changes
+        // are either the effect of a press of ours or an external one
+        if (this._remoteCapsLock !== null && capsLock !== this._remoteCapsLock) {
+            if (this._capsLockAwaitingLed) {
+                this._capsLockAwaitingLed = false;
+            } else {
+                // the guest changed Caps Lock on its own (reboot, snapshot,
+                // another client): follow the local keyboard again
+                this._capsLockInverted = false;
+            }
+        }
+        this._remoteCapsLock = capsLock;
 
         this.dispatchEvent(new CustomEvent(
             "ledstate",

--- a/docs/API.md
+++ b/docs/API.md
@@ -21,6 +21,13 @@ protocol stream.
     movement) should be prevented from being sent to the server.
     Disabled by default.
 
+`capsLockSync`
+  - Is a `boolean` indicating if the remote Caps Lock should be kept in
+    sync with the local keyboard (requires the server to report
+    [`ledstate`](#ledstate)). Enabled by default; disable it while
+    injecting key events that must not be affected by a Caps Lock
+    change.
+
 `focusOnClick`
   - Is a `boolean` indicating if keyboard focus should automatically be
     moved to the remote session when a `mousedown` or `touchstart`
@@ -124,6 +131,9 @@ protocol stream.
 
 [`RFB.sendCtrlAltDel()`](#rfbsendctrlaltdel)
   - Send Ctrl-Alt-Del key sequence.
+
+[`RFB.toggleCapsLock()`](#rfbtogglecapslock)
+  - Toggle Caps Lock on the remote session.
 
 [`RFB.focus()`](#rfbfocus)
   - Move keyboard focus to the remote session.
@@ -319,6 +329,19 @@ around [`RFB.sendKey()`](#rfbsendkey).
 ##### Syntax
 
     RFB.sendCtrlAltDel( );
+
+#### RFB.toggleCapsLock()
+
+The `RFB.toggleCapsLock()` method sends a *Caps Lock* key press to the
+remote session and keeps the new state: the remote Caps Lock normally
+follows the local keyboard (when the server reports
+[`ledstate`](#ledstate)), and after this call the relation between
+the two that results from the toggle is kept until the next call or
+until the remote side changes Caps Lock on its own.
+
+##### Syntax
+
+    RFB.toggleCapsLock( );
 
 #### RFB.focus()
 

--- a/tests/test.rfb.js
+++ b/tests/test.rfb.js
@@ -2314,6 +2314,180 @@ describe('Remote Frame Buffer Protocol Client', function () {
             });
         });
 
+        describe('Caps Lock sync with the local keyboard', function () {
+            function sendLedState(state) {
+                let data = [0, 0];       // FramebufferUpdate, padding
+                push16(data, 1);         // one rect
+                push16(data, 0); push16(data, 0); push16(data, 1); push16(data, 1);
+                push32(data, -261);      // QEMU LED state pseudo-encoding
+                push8(data, state);
+                client._sock._websocket._receive_data(new Uint8Array(data));
+            }
+
+            beforeEach(function () {
+                sinon.stub(client, 'sendKey');
+            });
+
+            it('should fix the remote caps lock when it differs from the local keyboard', function () {
+                sendLedState(0b100);
+                client._handleKeyEvent(0x61, 'KeyA', true, null, false);
+
+                expect(client.sendKey).to.have.been.calledTwice;
+                expect(client.sendKey.firstCall).to.have.been.calledWith(0xFFE5, 'CapsLock');
+                expect(client.sendKey.secondCall).to.have.been.calledWith(0x61, 'KeyA', true);
+            });
+
+            it('should not fix again before the guest confirms the fix', function () {
+                sendLedState(0b100);
+                client._handleKeyEvent(0x61, 'KeyA', true, null, false);
+                client._handleKeyEvent(0x62, 'KeyB', true, null, false);
+
+                expect(client.sendKey).to.have.callCount(3);
+                expect(client.sendKey.lastCall).to.have.been.calledWith(0x62, 'KeyB', true);
+            });
+
+            it('should follow the local keyboard again once the guest confirmed', function () {
+                sendLedState(0b100);
+                client._handleKeyEvent(0x61, 'KeyA', true, null, false);
+                sendLedState(0b000);
+                client.sendKey.resetHistory();
+
+                client._handleKeyEvent(0x61, 'KeyA', true, null, false);
+                expect(client.sendKey).to.have.been.calledOnce;
+
+                client._handleKeyEvent(0x41, 'KeyA', true, null, true);
+                expect(client.sendKey).to.have.callCount(3);
+                expect(client.sendKey.getCall(1)).to.have.been.calledWith(0xFFE5, 'CapsLock');
+            });
+
+            it('should keep the state toggled by the toolbar button', function () {
+                sendLedState(0b000);
+                client.toggleCapsLock();
+                expect(client.sendKey).to.have.been.calledWith(0xFFE5, 'CapsLock');
+                sendLedState(0b100);
+                client.sendKey.resetHistory();
+
+                client._handleKeyEvent(0x61, 'KeyA', true, null, false);
+                expect(client.sendKey).to.have.been.calledOnce;
+                expect(client.sendKey.firstCall).to.have.been.calledWith(0x61, 'KeyA', true);
+                expect(client._capsLockInverted).to.be.true;
+            });
+
+            it('should keep the offset across a physical caps lock press', function () {
+                sendLedState(0b000);
+                client.toggleCapsLock();
+                sendLedState(0b100);
+                client._handleKeyEvent(0x61, 'KeyA', true, null, false);
+                client.sendKey.resetHistory();
+
+                client._handleKeyEvent(0xFFE5, 'CapsLock', true, null, true);
+                sendLedState(0b000);
+                client._handleKeyEvent(0x41, 'KeyA', true, null, true);
+
+                expect(client.sendKey).to.have.been.calledTwice;
+                expect(client.sendKey.firstCall).to.have.been.calledWith(0xFFE5, 'CapsLock', true);
+                expect(client.sendKey.secondCall).to.have.been.calledWith(0x41, 'KeyA', true);
+                expect(client._capsLockInverted).to.be.true;
+            });
+
+            it('should drop the offset when the guest changes caps lock on its own', function () {
+                sendLedState(0b000);
+                client.toggleCapsLock();
+                sendLedState(0b100);
+                client._handleKeyEvent(0x61, 'KeyA', true, null, false);
+                client.sendKey.resetHistory();
+
+                sendLedState(0b000);
+                expect(client._capsLockInverted).to.be.false;
+                client._handleKeyEvent(0x61, 'KeyA', true, null, false);
+                expect(client.sendKey).to.have.been.calledOnce;
+
+                sendLedState(0b100);
+                client._handleKeyEvent(0x61, 'KeyA', true, null, false);
+                expect(client.sendKey).to.have.callCount(3);
+                expect(client.sendKey.getCall(1)).to.have.been.calledWith(0xFFE5, 'CapsLock');
+            });
+
+            it('should wait for both updates after two quick toggles', function () {
+                sendLedState(0b000);
+                client.toggleCapsLock();
+                client.toggleCapsLock();
+                client.sendKey.resetHistory();
+
+                client._handleKeyEvent(0x61, 'KeyA', true, null, false);
+                expect(client.sendKey).to.have.been.calledOnce;
+
+                sendLedState(0b100);
+                sendLedState(0b000);
+                client._handleKeyEvent(0x61, 'KeyA', true, null, false);
+                expect(client.sendKey).to.have.been.calledTwice;
+                expect(client._capsLockInverted).to.be.false;
+            });
+
+            it('should follow the local keyboard when the pointer moves over the screen', function () {
+                sendLedState(0b000);
+                client._handleMouseMove(1, 1, true);
+
+                expect(client.sendKey).to.have.been.calledOnce;
+                expect(client.sendKey.firstCall).to.have.been.calledWith(0xFFE5, 'CapsLock');
+
+                client._handleMouseMove(2, 2, true);
+                expect(client.sendKey).to.have.been.calledOnce;
+            });
+
+            it('should not count the first LED report as the result of a toggle', function () {
+                client.toggleCapsLock();
+                sendLedState(0b000);
+                expect(client._capsLockAwaitingLed).to.be.true;
+                sendLedState(0b100);
+                expect(client._capsLockAwaitingLed).to.be.false;
+                client.sendKey.resetHistory();
+
+                client._handleKeyEvent(0x61, 'KeyA', true, null, false);
+                expect(client.sendKey).to.have.been.calledOnce;
+                expect(client._capsLockInverted).to.be.true;
+            });
+
+            it('should not keep waiting for LED reports on a repeated caps lock key', function () {
+                sendLedState(0b000);
+                client._handleKeyEvent(0xFFE5, 'CapsLock', true, null, false);
+                client._handleKeyEvent(0xFFE5, 'CapsLock', true, null, false);
+                sendLedState(0b100);
+                client.sendKey.resetHistory();
+
+                client._handleKeyEvent(0x61, 'KeyA', true, null, false);
+                expect(client.sendKey).to.have.been.calledTwice;
+                expect(client.sendKey.firstCall).to.have.been.calledWith(0xFFE5, 'CapsLock');
+            });
+
+            it('should not touch caps lock while the sync is disabled', function () {
+                sendLedState(0b100);
+                client.capsLockSync = false;
+                client._handleKeyEvent(0x61, 'KeyA', true, null, false);
+                expect(client.sendKey).to.have.been.calledOnce;
+                client.capsLockSync = true;
+                client._handleKeyEvent(0x61, 'KeyA', true, null, false);
+                expect(client.sendKey).to.have.been.calledThrice;
+            });
+
+            it('should leave caps lock alone when the local state is unknown', function () {
+                sendLedState(0b100);
+                client._handleKeyEvent(0x61, 'KeyA', true, null, null);
+
+                expect(client.sendKey).to.have.been.calledOnce;
+                expect(client.sendKey.firstCall).to.have.been.calledWith(0x61, 'KeyA', true);
+            });
+
+            it('should report the LED state as an event', function () {
+                const spy = sinon.spy();
+                client.addEventListener('ledstate', spy);
+                sendLedState(0b110);
+
+                expect(spy).to.have.been.calledOnce;
+                expect(spy.args[0][0].detail).to.deep.equal({ capsLock: true, numLock: true });
+            });
+        });
+
         describe('WebSocket event handlers', function () {
             // message events
             it('should do nothing if we receive an empty message and have nothing in the queue', function () {


### PR DESCRIPTION
## CDI-2213: follow the local Caps Lock in the guest

### Why
After 1.1.0 the guest keeps its own Caps Lock, so a Caps Lock enabled *outside* the console (another window, before entering) was not reflected in the VM and typing came out inverted until the key or the toolbar button was pressed once. Testers also expected the toolbar indicator to change without typing.

### Behaviour
- The guest Caps Lock follows the local keyboard. Browsers report the Caps Lock state with key **and pointer** events, so a change made outside the console is applied as soon as the pointer is back over the screen or the first key is typed. A stuck guest Caps Lock is cleared the same way.
- The Caps Lock toolbar button still toggles the guest and its result is kept: the relation to the local keyboard that results from the toggle is maintained until the next click or until the guest changes Caps Lock on its own (reboot, snapshot revert, another client). The button highlight mirrors the guest LED as before.
- Nothing is learned or fixed while a Caps Lock press of ours has not been reported back by the guest, so LED reports in flight (double click, held key with auto-repeat) cannot undo it; a press the guest ignores just leaves the sync idle until the next reported change.
- The clipboard panel compensates the guest Caps Lock when typing the text and pauses the sync meanwhile (new `RFB.capsLockSync` property, documented in `docs/API.md`).
- iOS reports no usable Caps Lock state and keeps the previous behaviour.

### Verification
- Unit tests: 12 new cases in `tests/test.rfb.js` (fix, no double fix, confirmation, toolbar toggle kept, physical Caps Lock keeps the offset, external change drops it, two quick toggles, key auto-repeat, sync disabled, pointer movement, first LED report, unknown local state). Suite: 345 passed; the 33 failures are pre-existing on `master` (identical set).
- Lab replica of production (QEMU 10, `lock-key-sync=on`, no `-k`, websockify, Alpine guest), driven through Chrome DevTools with a simulated physical Caps Lock: `ABC` (Caps Lock enabled outside the console), `def`, `ghi` (stuck Caps Lock cleared), `JKLMNOpqr` (button both ways), `stu` (double click), `VwxYZ` (physical key after the button), `aXb` (external change), `hasloB` (paste with guest Caps Lock on); pointer movement alone updates the indicator; no JS errors.
- Reviewed with `/code-review` and Codex; all confirmed findings addressed.

### Known limitations
- Two clients sharing the session with different local Caps Lock states will keep toggling the guest (same as upstream noVNC's lock key sync).
- Windows guests and Firefox/Safari were not covered by the lab; please test on `SCTFAWINCLN01`.
- The static files are served without cache headers: after deployment a hard reload (Cmd/Ctrl+Shift+R) is needed to pick up the new modules.
